### PR TITLE
Work-a-round for missing doclet problems on Azul Zulu8 jdk.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -195,6 +195,24 @@
         </site>
       </distributionManagement>
     </profile>
+    <profile> 
+            <id>default-tools.jar</id>
+      <activation>
+        <property>
+          <name>java.vendor</name>
+          <value>Sun Microsystems Inc.</value>
+        </property>
+      </activation>
+      <dependencies>
+        <dependency>
+          <groupId>com.sun</groupId>
+          <artifactId>tools</artifactId>
+          <version>1.4.2</version>
+          <scope>system</scope>
+          <systemPath>${java.home}/../lib/tools.jar</systemPath>
+        </dependency>
+      </dependencies>
+    </profile>
   </profiles>
 
 


### PR DESCRIPTION
See http://maven.apache.org/general.html#tools-jar-dependency